### PR TITLE
Fix multireddits

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -2310,13 +2310,17 @@ class MultiredditMixin(AuthenticatedReddit):
         """
         url = self.config['multireddit_about'].format(user=self.user.name,
                                                       multi=name)
-        self.http.headers['x-modhash'] = self.modhash
+
+        # The modhash isn't necessary for OAuth requests
+        if not self._use_oauth:
+            self.http.headers['x-modhash'] = self.modhash
+
         try:
             self.request(url, data={}, method='DELETE', *args, **kwargs)
         finally:
-            del self.http.headers['x-modhash']
+            if not self._use_oauth:
+                del self.http.headers['x-modhash']
 
-    @decorators.restrict_access(scope='subscribe')
     def edit_multireddit(self, *args, **kwargs):
         """Edit a multireddit, or create one if it doesn't already exist.
 

--- a/tests/cassettes/test_accept_moderator_invite_fail.json
+++ b/tests/cassettes/test_accept_moderator_invite_fail.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_add_and_remove_subreddit.json
+++ b/tests/cassettes/test_add_and_remove_subreddit.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_add_comment.json
+++ b/tests/cassettes/test_add_comment.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_add_link_flair.json
+++ b/tests/cassettes/test_add_link_flair.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_add_link_flair_to_invalid_subreddit.json
+++ b/tests/cassettes/test_add_link_flair_to_invalid_subreddit.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_add_link_template.json
+++ b/tests/cassettes/test_add_link_template.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_add_moderator__failure.json
+++ b/tests/cassettes/test_add_moderator__failure.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_add_remove_friends.json
+++ b/tests/cassettes/test_add_remove_friends.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "user=PyAPITestUser2&api_type=json&passwd=1111"
+          "string": "user=PyAPITestUser2&api_type=json&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_add_reply.json
+++ b/tests/cassettes/test_add_reply.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_add_user_flair__css_only.json
+++ b/tests/cassettes/test_add_user_flair__css_only.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_add_user_flair__text_and_css.json
+++ b/tests/cassettes/test_add_user_flair__text_and_css.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_add_user_flair__text_only.json
+++ b/tests/cassettes/test_add_user_flair__text_only.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_add_user_flair_to_invalid_user.json
+++ b/tests/cassettes/test_add_user_flair_to_invalid_user.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_add_user_template.json
+++ b/tests/cassettes/test_add_user_template.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_all_comments.json
+++ b/tests/cassettes/test_all_comments.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_approve_and_remove.json
+++ b/tests/cassettes/test_approve_and_remove.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&passwd=1111&user=PyAPITestUser2"
+          "string": "api_type=json&passwd=111111&user=PyAPITestUser2"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_attribute_error.json
+++ b/tests/cassettes/test_attribute_error.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_ban.json
+++ b/tests/cassettes/test_ban.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_cache.json
+++ b/tests/cassettes/test_cache.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser4&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser4&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -96,7 +96,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&uh=51o5bapqnp0606f9e6ca043a82bc0eceb6f8209ba0b45b8143&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&uh=51o5bapqnp0606f9e6ca043a82bc0eceb6f8209ba0b45b8143&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_cache_hit_callback.json
+++ b/tests/cassettes/test_cache_hit_callback.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&api_type=json&user=PyAPITestUser2"
+          "string": "passwd=111111&api_type=json&user=PyAPITestUser2"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_clear_link_templates.json
+++ b/tests/cassettes/test_clear_link_templates.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_clear_user_flair.json
+++ b/tests/cassettes/test_clear_user_flair.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_clear_user_templates.json
+++ b/tests/cassettes/test_clear_user_templates.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_comments_method.json
+++ b/tests/cassettes/test_comments_method.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_contributors.json
+++ b/tests/cassettes/test_contributors.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_copy_multireddit.json
+++ b/tests/cassettes/test_copy_multireddit.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_create_and_delete_multireddit.json
+++ b/tests/cassettes/test_create_and_delete_multireddit.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&user=PyAPITestUser2&passwd=1111"
+          "string": "api_type=json&user=PyAPITestUser2&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_create_and_delete_redditor.json
+++ b/tests/cassettes/test_create_and_delete_redditor.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser3&api_type=json&email=&passwd2=1111"
+          "string": "passwd=111111&user=PyAPITestUser3&api_type=json&email=&passwd2=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_create_subreddit.json
+++ b/tests/cassettes/test_create_subreddit.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser4&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser4&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -100,7 +100,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&uh=itdlrd4kvw03a5c6f75d71a2cd0eed2a7f7478af168bb64e72&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&uh=itdlrd4kvw03a5c6f75d71a2cd0eed2a7f7478af168bb64e72&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_delete_flair.json
+++ b/tests/cassettes/test_delete_flair.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_delete_header.json
+++ b/tests/cassettes/test_delete_header.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_delete_image.json
+++ b/tests/cassettes/test_delete_image.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_delete_invalid_image.json
+++ b/tests/cassettes/test_delete_invalid_image.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_delete_invalid_params.json
+++ b/tests/cassettes/test_delete_invalid_params.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_display_name_lazy_update.json
+++ b/tests/cassettes/test_display_name_lazy_update.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&user=PyAPITestUser2&passwd=1111"
+          "string": "api_type=json&user=PyAPITestUser2&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_display_name_refresh.json
+++ b/tests/cassettes/test_display_name_refresh.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&user=PyAPITestUser2&passwd=1111"
+          "string": "api_type=json&user=PyAPITestUser2&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_distinguish_and_sticky.json
+++ b/tests/cassettes/test_distinguish_and_sticky.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_distinguish_and_undistinguish.json
+++ b/tests/cassettes/test_distinguish_and_undistinguish.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "user=PyAPITestUser2&passwd=1111&api_type=json"
+          "string": "user=PyAPITestUser2&passwd=111111&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_duplicate_login.json
+++ b/tests/cassettes/test_duplicate_login.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -94,7 +94,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&uh=44eayop6ee06b485708d27bc43aada6787e83b56103d90c18a&user=PyAPITestUser3&api_type=json"
+          "string": "passwd=111111&uh=44eayop6ee06b485708d27bc43aada6787e83b56103d90c18a&user=PyAPITestUser3&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_edit.json
+++ b/tests/cassettes/test_edit.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_edit_multireddit.json
+++ b/tests/cassettes/test_edit_multireddit.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&user=PyAPITestUser2&passwd=1111"
+          "string": "api_type=json&user=PyAPITestUser2&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_edit_wiki_page.json
+++ b/tests/cassettes/test_edit_wiki_page.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "user=PyAPITestUser2&passwd=1111&api_type=json"
+          "string": "user=PyAPITestUser2&passwd=111111&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_edit_wiki_page_editors.json
+++ b/tests/cassettes/test_edit_wiki_page_editors.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&user=PyAPITestUser2&passwd=1111"
+          "string": "api_type=json&user=PyAPITestUser2&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_edit_wiki_page_settings.json
+++ b/tests/cassettes/test_edit_wiki_page_settings.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&user=PyAPITestUser2&passwd=1111"
+          "string": "api_type=json&user=PyAPITestUser2&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_equality_and_hash.json
+++ b/tests/cassettes/test_equality_and_hash.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_flair_csv_and_flair_list.json
+++ b/tests/cassettes/test_flair_csv_and_flair_list.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_flair_csv_empty.json
+++ b/tests/cassettes/test_flair_csv_empty.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_flair_csv_many.json
+++ b/tests/cassettes/test_flair_csv_many.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_flair_csv_optional_args.json
+++ b/tests/cassettes/test_flair_csv_optional_args.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_flair_csv_requires_user.json
+++ b/tests/cassettes/test_flair_csv_requires_user.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_front_page_comment_replies_are_none.json
+++ b/tests/cassettes/test_front_page_comment_replies_are_none.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_banned__note.json
+++ b/tests/cassettes/test_get_banned__note.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_comment_replies.json
+++ b/tests/cassettes/test_get_comment_replies.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_comments_permalink.json
+++ b/tests/cassettes/test_get_comments_permalink.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_contributors_private.json
+++ b/tests/cassettes/test_get_contributors_private.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -130,7 +130,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&uh=7t3of30c7saedb39c9782b757de93a597b5d5630b7eb65c214&user=PyAPITestUser4&api_type=json"
+          "string": "passwd=111111&uh=7t3of30c7saedb39c9782b757de93a597b5d5630b7eb65c214&user=PyAPITestUser4&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_contributors_public.json
+++ b/tests/cassettes/test_get_contributors_public.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_contributors_public_exception.json
+++ b/tests/cassettes/test_get_contributors_public_exception.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -130,7 +130,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&uh=bz4m6issio88441b9620674b49114c8c02f38fb3665418bad1&user=PyAPITestUser4&api_type=json"
+          "string": "passwd=111111&uh=bz4m6issio88441b9620674b49114c8c02f38fb3665418bad1&user=PyAPITestUser4&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_flair_list.json
+++ b/tests/cassettes/test_get_flair_list.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -94,7 +94,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&uh=scuqksiby015d12ea4d09e9454ee55d04ff29eca08006f7000&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&uh=scuqksiby015d12ea4d09e9454ee55d04ff29eca08006f7000&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_hidden.json
+++ b/tests/cassettes/test_get_hidden.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "user=PyAPITestUser2&api_type=json&passwd=1111"
+          "string": "user=PyAPITestUser2&api_type=json&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_message.json
+++ b/tests/cassettes/test_get_message.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_mod_log.json
+++ b/tests/cassettes/test_get_mod_log.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_mod_log_with_action_filter.json
+++ b/tests/cassettes/test_get_mod_log_with_action_filter.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_mod_log_with_mod_by_name.json
+++ b/tests/cassettes/test_get_mod_log_with_mod_by_name.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_mod_log_with_mod_by_redditor_object.json
+++ b/tests/cassettes/test_get_mod_log_with_mod_by_redditor_object.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_mod_queue.json
+++ b/tests/cassettes/test_get_mod_queue.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_mod_queue_multi.json
+++ b/tests/cassettes/test_get_mod_queue_multi.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_mod_queue_with_default_subreddit.json
+++ b/tests/cassettes/test_get_mod_queue_with_default_subreddit.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_multireddit.json
+++ b/tests/cassettes/test_get_multireddit.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_my_contributions.json
+++ b/tests/cassettes/test_get_my_contributions.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_my_moderation.json
+++ b/tests/cassettes/test_get_my_moderation.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_my_multis.json
+++ b/tests/cassettes/test_get_my_multis.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_my_subreddits.json
+++ b/tests/cassettes/test_get_my_subreddits.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_post_replies.json
+++ b/tests/cassettes/test_get_post_replies.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_redditor.json
+++ b/tests/cassettes/test_get_redditor.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_submitted.json
+++ b/tests/cassettes/test_get_submitted.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_subreddit_recommendations.json
+++ b/tests/cassettes/test_get_subreddit_recommendations.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_unmoderated.json
+++ b/tests/cassettes/test_get_unmoderated.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_unread_update_has_mail.json
+++ b/tests/cassettes/test_get_unread_update_has_mail.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -225,7 +225,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&uh=vq8b7k4maobff3d78acad7c43b6874ff2f7c0ed5db718cbffe&user=PyAPITestUser3&api_type=json"
+          "string": "passwd=111111&uh=vq8b7k4maobff3d78acad7c43b6874ff2f7c0ed5db718cbffe&user=PyAPITestUser3&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_upvoted_and_downvoted.json
+++ b/tests/cassettes/test_get_upvoted_and_downvoted.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&user=PyAPITestUser2&passwd=1111"
+          "string": "api_type=json&user=PyAPITestUser2&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_wiki_page.json
+++ b/tests/cassettes/test_get_wiki_page.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_get_wiki_pages.json
+++ b/tests/cassettes/test_get_wiki_pages.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&user=PyAPITestUser2&passwd=1111"
+          "string": "api_type=json&user=PyAPITestUser2&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_ignore_and_unignore_reports.json
+++ b/tests/cassettes/test_ignore_and_unignore_reports.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_inbox_comment_permalink.json
+++ b/tests/cassettes/test_inbox_comment_permalink.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_inbox_comment_replies_are_none.json
+++ b/tests/cassettes/test_inbox_comment_replies_are_none.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_lock_and_unlock.json
+++ b/tests/cassettes/test_lock_and_unlock.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_login__deprecation_warning.json
+++ b/tests/cassettes/test_login__deprecation_warning.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser4&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser4&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -96,7 +96,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&uh=6o3c7nf4b6e5780173c4183163fee866e9ec5a85c609088e2b&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&uh=6o3c7nf4b6e5780173c4183163fee866e9ec5a85c609088e2b&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_mark_as_nsfw__exception.json
+++ b/tests/cassettes/test_mark_as_nsfw__exception.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_mark_as_nsfw_and_umark_as_nsfw__as_author.json
+++ b/tests/cassettes/test_mark_as_nsfw_and_umark_as_nsfw__as_author.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "user=PyAPITestUser2&passwd=1111&api_type=json"
+          "string": "user=PyAPITestUser2&passwd=111111&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -97,7 +97,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "user=PyAPITestUser4&passwd=1111&api_type=json&uh=7jptsa5122089867085e1c8f4404ee5362f9dbc958f0b6e827"
+          "string": "user=PyAPITestUser4&passwd=111111&api_type=json&uh=7jptsa5122089867085e1c8f4404ee5362f9dbc958f0b6e827"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_mark_as_nsfw_and_umark_as_nsfw__as_moderator.json
+++ b/tests/cassettes/test_mark_as_nsfw_and_umark_as_nsfw__as_moderator.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "user=PyAPITestUser2&passwd=1111&api_type=json"
+          "string": "user=PyAPITestUser2&passwd=111111&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_mark_as_read.json
+++ b/tests/cassettes/test_mark_as_read.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -130,7 +130,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&uh=b9mc02mfhadda33601a8ace302fc575b290bccf8112781e97c&user=PyAPITestUser3&api_type=json"
+          "string": "passwd=111111&uh=b9mc02mfhadda33601a8ace302fc575b290bccf8112781e97c&user=PyAPITestUser3&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_mark_as_unread.json
+++ b/tests/cassettes/test_mark_as_unread.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -130,7 +130,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&uh=6sz9yqaxnp2b9a9e4975b04fa533a6adc4f6dc9e21acb18339&user=PyAPITestUser3&api_type=json"
+          "string": "passwd=111111&uh=6sz9yqaxnp2b9a9e4975b04fa533a6adc4f6dc9e21acb18339&user=PyAPITestUser3&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_mark_multiple_as_read.json
+++ b/tests/cassettes/test_mark_multiple_as_read.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -130,7 +130,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&uh=sp2dllusuv655deaafb051a5bacbcf1e63a3fe22619a307ceb&user=PyAPITestUser3&api_type=json"
+          "string": "passwd=111111&uh=sp2dllusuv655deaafb051a5bacbcf1e63a3fe22619a307ceb&user=PyAPITestUser3&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_mod_mail_send.json
+++ b/tests/cassettes/test_mod_mail_send.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_moderator.json
+++ b/tests/cassettes/test_moderator.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -289,7 +289,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&uh=ba3hzmb9bxfa39b86c464aaecccf492ec3d5d734b8e1b22199&user=PyAPITestUser3&api_type=json"
+          "string": "passwd=111111&uh=ba3hzmb9bxfa39b86c464aaecccf492ec3d5d734b8e1b22199&user=PyAPITestUser3&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -475,7 +475,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&uh=rnnu1bu8m54e16bd09ebfdf2ec66d2ef87b6813dff6289687f&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&uh=rnnu1bu8m54e16bd09ebfdf2ec66d2ef87b6813dff6289687f&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_moderator_or_oauth_required__logged_in_from_reddit_obj.json
+++ b/tests/cassettes/test_moderator_or_oauth_required__logged_in_from_reddit_obj.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser4&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser4&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_moderator_or_oauth_required__logged_in_from_submission_obj.json
+++ b/tests/cassettes/test_moderator_or_oauth_required__logged_in_from_submission_obj.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser4&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser4&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_moderator_or_oauth_required__logged_in_from_subreddit_obj.json
+++ b/tests/cassettes/test_moderator_or_oauth_required__logged_in_from_subreddit_obj.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser4&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser4&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_moderator_required__multi.json
+++ b/tests/cassettes/test_moderator_required__multi.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser4&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser4&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_multiple_subreddit__fetch.json
+++ b/tests/cassettes/test_multiple_subreddit__fetch.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_multireddit_get_new.json
+++ b/tests/cassettes/test_multireddit_get_new.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_name_lazy_update.json
+++ b/tests/cassettes/test_name_lazy_update.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&passwd=1111&user=PyAPITestUser2"
+          "string": "api_type=json&passwd=111111&user=PyAPITestUser2"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_pickling_v0.json
+++ b/tests/cassettes/test_pickling_v0.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "user=PyAPITestUser2&api_type=json&passwd=1111"
+          "string": "user=PyAPITestUser2&api_type=json&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_pickling_v1.json
+++ b/tests/cassettes/test_pickling_v1.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "user=PyAPITestUser2&api_type=json&passwd=1111"
+          "string": "user=PyAPITestUser2&api_type=json&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_pickling_v2.json
+++ b/tests/cassettes/test_pickling_v2.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "user=PyAPITestUser2&api_type=json&passwd=1111"
+          "string": "user=PyAPITestUser2&api_type=json&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_redditor_comparison.json
+++ b/tests/cassettes/test_redditor_comparison.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_rename_multireddit.json
+++ b/tests/cassettes/test_rename_multireddit.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&user=PyAPITestUser2&passwd=1111"
+          "string": "api_type=json&user=PyAPITestUser2&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_reply_to_message_and_verify.json
+++ b/tests/cassettes/test_reply_to_message_and_verify.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_report.json
+++ b/tests/cassettes/test_report.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_revision_by.json
+++ b/tests/cassettes/test_revision_by.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&user=PyAPITestUser2&passwd=1111"
+          "string": "api_type=json&user=PyAPITestUser2&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_save_comment.json
+++ b/tests/cassettes/test_save_comment.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_save_submission.json
+++ b/tests/cassettes/test_save_submission.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "user=PyAPITestUser2&passwd=1111&api_type=json"
+          "string": "user=PyAPITestUser2&passwd=111111&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_select_link_flair.json
+++ b/tests/cassettes/test_select_link_flair.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_select_link_flair_custom_text.json
+++ b/tests/cassettes/test_select_link_flair_custom_text.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_select_link_flair_remove.json
+++ b/tests/cassettes/test_select_link_flair_remove.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_select_user_flair.json
+++ b/tests/cassettes/test_select_user_flair.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_select_user_flair_custom_text.json
+++ b/tests/cassettes/test_select_user_flair_custom_text.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_select_user_flair_remove.json
+++ b/tests/cassettes/test_select_user_flair_remove.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_send.json
+++ b/tests/cassettes/test_send.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_send_from_sr.json
+++ b/tests/cassettes/test_send_from_sr.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_send_from_subreddit.json
+++ b/tests/cassettes/test_send_from_subreddit.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -225,7 +225,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&uh=eyv6uq26cqcb5cae09c47ad50708e7e3e42b505be2a50b9720&user=PyAPITestUser3&api_type=json"
+          "string": "passwd=111111&uh=eyv6uq26cqcb5cae09c47ad50708e7e3e42b505be2a50b9720&user=PyAPITestUser3&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_send_invalid.json
+++ b/tests/cassettes/test_send_invalid.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_set_settings.json
+++ b/tests/cassettes/test_set_settings.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_set_stylesheet.json
+++ b/tests/cassettes/test_set_stylesheet.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_set_suggested_sort.json
+++ b/tests/cassettes/test_set_suggested_sort.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "user=PyAPITestUser2&passwd=1111&api_type=json"
+          "string": "user=PyAPITestUser2&passwd=111111&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_short_link.json
+++ b/tests/cassettes/test_short_link.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_spambox_comments_replies_are_none.json
+++ b/tests/cassettes/test_spambox_comments_replies_are_none.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_sticky_unsticky.json
+++ b/tests/cassettes/test_sticky_unsticky.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&user=PyAPITestUser2&passwd=1111"
+          "string": "api_type=json&user=PyAPITestUser2&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_submission_delete.json
+++ b/tests/cassettes/test_submission_delete.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&passwd=1111&user=PyAPITestUser2"
+          "string": "api_type=json&passwd=111111&user=PyAPITestUser2"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_submission_edit__link_failure.json
+++ b/tests/cassettes/test_submission_edit__link_failure.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_submission_edit__self.json
+++ b/tests/cassettes/test_submission_edit__self.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_submission_hide_and_unhide.json
+++ b/tests/cassettes/test_submission_hide_and_unhide.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "user=PyAPITestUser2&passwd=1111&api_type=json"
+          "string": "user=PyAPITestUser2&passwd=111111&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_submission_hide_and_unhide_batch.json
+++ b/tests/cassettes/test_submission_hide_and_unhide_batch.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&api_type=json&user=PyAPITestUser2"
+          "string": "passwd=111111&api_type=json&user=PyAPITestUser2"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_submission_hide_and_unhide_many.json
+++ b/tests/cassettes/test_submission_hide_and_unhide_many.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&api_type=json&user=PyAPITestUser2"
+          "string": "passwd=111111&api_type=json&user=PyAPITestUser2"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_submission_refresh.json
+++ b/tests/cassettes/test_submission_refresh.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&user=PyAPITestUser2&passwd=1111"
+          "string": "api_type=json&user=PyAPITestUser2&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_submit__duplicate_url.json
+++ b/tests/cassettes/test_submit__duplicate_url.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "user=PyAPITestUser2&passwd=1111&api_type=json"
+          "string": "user=PyAPITestUser2&passwd=111111&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_submit__invalid_arguments.json
+++ b/tests/cassettes/test_submit__invalid_arguments.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_submit__self.json
+++ b/tests/cassettes/test_submit__self.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_submit__self_with_no_body.json
+++ b/tests/cassettes/test_submit__self_with_no_body.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_subreddit_refresh.json
+++ b/tests/cassettes/test_subreddit_refresh.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&user=PyAPITestUser2&passwd=1111"
+          "string": "api_type=json&user=PyAPITestUser2&passwd=111111"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_subreddit_search.json
+++ b/tests/cassettes/test_subreddit_search.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_subscribe_and_unsubscribe.json
+++ b/tests/cassettes/test_subscribe_and_unsubscribe.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_unicode_comment.json
+++ b/tests/cassettes/test_unicode_comment.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_unicode_submission.json
+++ b/tests/cassettes/test_unicode_submission.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&passwd=1111&user=PyAPITestUser2"
+          "string": "api_type=json&passwd=111111&user=PyAPITestUser2"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_unique_count_zero.json
+++ b/tests/cassettes/test_unique_count_zero.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "user=PyAPITestUser2&passwd=1111&api_type=json"
+          "string": "user=PyAPITestUser2&passwd=111111&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_update_settings__descriptions.json
+++ b/tests/cassettes/test_update_settings__descriptions.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_upload_invalid_file_path.json
+++ b/tests/cassettes/test_upload_invalid_file_path.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_upload_invalid_image.json
+++ b/tests/cassettes/test_upload_invalid_image.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_upload_invalid_image_path.json
+++ b/tests/cassettes/test_upload_invalid_image_path.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_upload_invalid_image_too_large.json
+++ b/tests/cassettes/test_upload_invalid_image_too_large.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_upload_invalid_image_too_small.json
+++ b/tests/cassettes/test_upload_invalid_image_too_small.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_upload_invalid_params.json
+++ b/tests/cassettes/test_upload_invalid_params.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_upload_jpg_header.json
+++ b/tests/cassettes/test_upload_jpg_header.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_user_comment_permalink.json
+++ b/tests/cassettes/test_user_comment_permalink.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_user_comment_replies_are_none.json
+++ b/tests/cassettes/test_user_comment_replies_are_none.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_user_set_on_login.json
+++ b/tests/cassettes/test_user_set_on_login.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_voting.json
+++ b/tests/cassettes/test_voting.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "user=PyAPITestUser2&passwd=1111&api_type=json"
+          "string": "user=PyAPITestUser2&passwd=111111&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_wiki_ban.json
+++ b/tests/cassettes/test_wiki_ban.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "passwd=111111&user=PyAPITestUser2&api_type=json"
         },
         "headers": {
           "Accept": [

--- a/tests/cassettes/test_wiki_contributors.json
+++ b/tests/cassettes/test_wiki_contributors.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&api_type=json&user=PyAPITestUser2"
+          "string": "passwd=111111&api_type=json&user=PyAPITestUser2"
         },
         "headers": {
           "Accept": [

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -72,9 +72,9 @@ class PRAWTest(unittest.TestCase):
         self.other_user_name = 'PyAPITestUser3'
         self.other_non_mod_name = 'PyAPITestUser4'
         self.invalid_user_name = 'PyAPITestInvalid'
-        self.un_pswd = '1111'
-        self.other_user_pswd = '1111'
-        self.other_non_mod_pswd = '1111'
+        self.un_pswd = '111111'
+        self.other_user_pswd = '111111'
+        self.other_non_mod_pswd = '111111'
 
         self.client_id = 'stJlUSUbPQe5lQ'
         self.client_secret = 'iU-LsOzyJH7BDVoq-qOWNEq2zuI'


### PR DESCRIPTION
This fixes three bugs related to the multireddit commands (subscribe, unsubscribe, delete, etc.) and OAuth. Two of the bugs were discovered thanks to @woorst [here](https://github.com/michael-lazar/praw3/pull/2). I'm rolling that PR into this one.

- ``Multireddit.add_subreddit`` and ``reddit.delete_multireddit`` were hardcoded to insert the **x-modhash** header. The header is required for basic auth, but it was removed when OAuth came around and the code was raising an error.
- The multireddit path is now returned with a slash (**/user/redditor/m/multi/**), which was causing a parsing error in the ``Multireddit`` object.
- Several of the Multireddit methods were using the ``@restrict_access`` decorator in two places which was causing an assertion error when using OAuth.

I have written tests for this functionality but I will add them on the **rtv** side because it's a lot easier to do it over there. I also noticed that the cache wasn't evicting the subreddit list after unsubscribing, that will also be fixed on the **rtv** side because I have a custom rate limiter [here](https://github.com/michael-lazar/rtv/blob/master/rtv/content.py#L786).